### PR TITLE
Add simple elf image generator app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Elf Image Generator
+
+This simple Flask application lets you generate images of elves using OpenAI's image generation API. Enter a description and the backend will request an image from OpenAI and display it in the browser.
+
+## Installation
+
+1. **Create a virtual environment (optional)**
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. **Install dependencies**
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. **Set your OpenAI API key**
+   ```bash
+   export OPENAI_API_KEY=your-key-here
+   ```
+
+## Running the Application
+
+Run the Flask app with:
+
+```bash
+python app.py
+```
+
+By default the server starts on `http://localhost:5000`. Open this address in your browser to load `index.html`. Enter a prompt describing the desired elf and press **Generate**. The generated image will appear on the page.
+
+## Notes
+
+- The app uses OpenAI's API. Ensure you comply with their terms of service.
+- Alternatively, you can replace the image generation logic in `app.py` with a local Stable Diffusion pipeline if preferred.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,31 @@
+import os
+from flask import Flask, request, jsonify, send_from_directory
+import openai
+
+app = Flask(__name__)
+
+# Configure OpenAI API key via environment variable
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+@app.route('/')
+def index():
+    """Serve the frontend."""
+    return send_from_directory('.', 'index.html')
+
+@app.route('/generate', methods=['POST'])
+def generate():
+    """Generate an elf image based on the provided text prompt."""
+    data = request.get_json() or {}
+    prompt = data.get('prompt', '')
+    if not prompt:
+        return jsonify({'error': 'No prompt provided'}), 400
+
+    try:
+        response = openai.Image.create(prompt=prompt, n=1, size="512x512")
+        image_url = response['data'][0]['url']
+        return jsonify({'url': image_url})
+    except Exception as exc:
+        return jsonify({'error': str(exc)}), 500
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Elf Image Generator</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 40px; }
+        #result-image { margin-top: 20px; max-width: 512px; }
+    </style>
+</head>
+<body>
+    <h1>Generate an Elf Image</h1>
+    <form id="generate-form">
+        <input type="text" id="prompt" placeholder="Describe your elf" required>
+        <button type="submit">Generate</button>
+    </form>
+    <div id="result">
+        <img id="result-image" alt="Your generated elf will appear here" />
+    </div>
+    <script>
+        const form = document.getElementById('generate-form');
+        const img = document.getElementById('result-image');
+        form.addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const prompt = document.getElementById('prompt').value;
+            img.src = '';
+            const response = await fetch('/generate', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ prompt })
+            });
+            if (response.ok) {
+                const data = await response.json();
+                img.src = data.url;
+            } else {
+                const error = await response.json();
+                alert(error.error || 'An error occurred');
+            }
+        });
+    </script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+openai


### PR DESCRIPTION
## Summary
- create `app.py` with Flask backend calling OpenAI image API
- add form and JS to `index.html` for prompt submission and showing results
- document setup and usage in `README.md`
- specify dependencies in `requirements.txt`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68474d757ec4832caaae7d20d2a1e61f